### PR TITLE
Use Tailwind's built-in `purge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,16 @@ Some notable features of the authentication scaffolding include:
 
 All routes, components, controllers and tests are published to your application. The idea behind this is that you have full control over every aspect of the scaffolding in your own app, removing the need to dig around in the vendor folder to figure out how things are working.
 
+## CSS purging
+
+Tailwind uses PurgeCSS to remove any unused classes from your production CSS builds. You can modify or remove this behaviour in the `purge` section of your `tailwind.config.js` file. For more information, please see the [Tailwind documentation](https://tailwindcss.com/docs/controlling-file-size/).
+
 ## Removing the package
 
 If you don't want to keep this package installed once you've installed the preset, you can safely remove it. Unlike the default Laravel presets, this one publishes all the auth logic to your project's `/app` directory, so it's fully redundant.
 
 
-## A note on pagination
+### A note on pagination
 
 If you are using pagination, you set the default pagination views to the ones provided in the `boot` method of a service provider:
 
@@ -70,10 +74,6 @@ class AppServiceProvider extends ServiceProvider
     }
 }
 ```
-
-## A note on production CSS purging
-
-By default, Tailwind will run PurgeCSS looking within your `resources/views` and `resources/css` directories for classes to keep. You can change (or entirely disable) this behavior by changing the `purge` section of your `tailwind.config.js` file. For more information about Tailwind's implementation of PurgeCSS, you can [read here](https://tailwindcss.com/docs/controlling-file-size/).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -75,15 +75,6 @@ class AppServiceProvider extends ServiceProvider
 
 By default, Tailwind will run PurgeCSS looking within your `resources/views` and `resources/css` directories for classes to keep. You can change (or entirely disable) this behavior by changing the `purge` section of your `tailwind.config.js` file. For more information about Tailwind's implementation of PurgeCSS, you can [read here](https://tailwindcss.com/docs/controlling-file-size/).
 
-For example, if your JavaScript files contain CSS classes, you will need to add the following to the `content` section so those classes don't get purged:
-
-```js
-content: [
-    ...
-    './resources/js/**/*.js',
-],
-```
-
 ## Credits
 
 - [Dan Harrin](https://github.com/DanHarrin)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All routes, components, controllers and tests are published to your application.
 If you don't want to keep this package installed once you've installed the preset, you can safely remove it. Unlike the default Laravel presets, this one publishes all the auth logic to your project's `/app` directory, so it's fully redundant.
 
 
-### A note on pagination
+## A note on pagination
 
 If you are using pagination, you set the default pagination views to the ones provided in the `boot` method of a service provider:
 
@@ -69,6 +69,19 @@ class AppServiceProvider extends ServiceProvider
         Paginator::defaultSimpleView('pagination::simple-default');
     }
 }
+```
+
+## A note on production CSS purging
+
+By default, Tailwind will run PurgeCSS looking within your `resources/views` and `resources/css` directories for classes to keep. You can change (or entirely disable) this behavior by changing the `purge` section of your `tailwind.config.js` file. For more information about Tailwind's implementation of PurgeCSS, you can [read here](https://tailwindcss.com/docs/controlling-file-size/).
+
+For example, if your JavaScript files contain CSS classes, you will need to add the following to the `content` section so those classes don't get purged:
+
+```js
+content: [
+    ...
+    './resources/js/**/*.js',
+],
 ```
 
 ## Credits

--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -12,9 +12,8 @@ class TallPreset extends Preset
         '@tailwindcss/custom-forms' => '^0.2',
         '@tailwindcss/ui' => '^0.1',
         'alpinejs' => '^2.0',
-        'laravel-mix-purgecss' => '^4.1',
         'laravel-mix-tailwind' => '^0.1.0',
-        'tailwindcss' => '^1.0',
+        'tailwindcss' => '^1.4',
     ];
 
     const NPM_PACKAGES_TO_REMOVE = [

--- a/stubs/default/tailwind.config.js
+++ b/stubs/default/tailwind.config.js
@@ -11,11 +11,19 @@ module.exports = {
     variants: {},
     purge: {
         content: [
-            './resources/views/**/*.blade.php',
-            './resources/css/**/*.css',
+            './app/**/*.php',
+            './resources/**/*.html',
+            './resources/**/*.js',
+            './resources/**/*.jsx',
+            './resources/**/*.ts',
+            './resources/**/*.tsx',
+            './resources/**/*.php',
+            './resources/**/*.vue',
+            './resources/**/*.twig',
         ],
         options: {
-            extractorPattern: /[\w-/.:]+(?<!:)/g,
+            defaultExtractor: (content) => content.match(/[\w-/.:]+(?<!:)/g) || [],
+            whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
         },
     },
     plugins: [

--- a/stubs/default/tailwind.config.js
+++ b/stubs/default/tailwind.config.js
@@ -1,4 +1,4 @@
-const defaultTheme = require('tailwindcss/defaultTheme')
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
     theme: {
@@ -9,8 +9,17 @@ module.exports = {
         },
     },
     variants: {},
+    purge: {
+        content: [
+            './resources/views/**/*.blade.php',
+            './resources/css/**/*.css',
+        ],
+        options: {
+            extractorPattern: /[\w-/.:]+(?<!:)/g,
+        },
+    },
     plugins: [
         require('@tailwindcss/custom-forms'),
         require('@tailwindcss/ui'),
-    ]
-}
+    ],
+};

--- a/stubs/default/webpack.mix.js
+++ b/stubs/default/webpack.mix.js
@@ -1,7 +1,6 @@
 const mix = require("laravel-mix");
 
 require("laravel-mix-tailwind");
-require("laravel-mix-purgecss");
 
 /*
  |--------------------------------------------------------------------------
@@ -20,8 +19,5 @@ mix.js("resources/js/app.js", "public/js/app.js")
     .sourceMaps();
 
 if (mix.inProduction()) {
-    mix.version()
-        .purgeCss({
-            extractorPattern: /[\w-/.:]+(?<!:)/g
-        });
+    mix.version();
 }


### PR DESCRIPTION
I don't know if this is something that anyone wants to do because it is incredibly opinionated, but I thought I would PR it anyway.

Tailwind v1.4 has PurgeCSS built-in now, so it's not strictly necessary we use Spatie's package. However, I know Tailwind's implementation does not automatically set up all the directories to scan.

This package will put the burden on the end developer to manage their own directories, but I can foresee an increase in tickets here because "CSS classes are missing".

If there are no objections, I will mark the PR as ready for review so it can be merged. Otherwise, we can close this PR.