### PR TITLE
Use Sass compilation by default

### DIFF
--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -19,8 +19,6 @@ class TallPreset extends Preset
     const NPM_PACKAGES_TO_REMOVE = [
         'lodash',
         'axios',
-        'sass',
-        'sass-loader',
     ];
 
     public static function install()

--- a/stubs/default/resources/sass/app.scss
+++ b/stubs/default/resources/sass/app.scss
@@ -4,19 +4,11 @@
  *
  * You can see the styles here:
  * https://unpkg.com/tailwindcss/dist/base.css
- *
- * If using `postcss-import`, use this import instead:
- *
- * @import "tailwindcss/base";
  */
 @tailwind base;
 
 /**
  * This injects any component classes registered by plugins.
- *
- * If using `postcss-import`, use this import instead:
- *
- * @import "tailwindcss/components";
  */
 @tailwind components;
 
@@ -29,20 +21,11 @@
  *
  * .btn { ... }
  * .form-input { ... }
- *
- * Or if using a preprocessor or `postcss-import`:
- *
- * @import "components/buttons";
- * @import "components/forms";
  */
 
 /**
  * This injects all of Tailwind's utility classes, generated based on your
  * config file.
- *
- * If using `postcss-import`, use this import instead:
- *
- * @import "tailwindcss/utilities";
  */
 @tailwind utilities;
 
@@ -54,9 +37,4 @@
  *
  * .bg-pattern-graph-paper { ... }
  * .skew-45 { ... }
- *
- * Or if using a preprocessor or `postcss-import`:
- *
- * @import "utilities/background-patterns";
- * @import "utilities/skew-transforms";
  */

--- a/stubs/default/webpack.mix.js
+++ b/stubs/default/webpack.mix.js
@@ -14,7 +14,7 @@ require("laravel-mix-tailwind");
  */
 
 mix.js("resources/js/app.js", "public/js/app.js")
-    .postCss("resources/css/app.css", "public/css/app.css")
+    .sass("resources/sass/app.scss", "public/css/app.css")
     .tailwind("./tailwind.config.js")
     .sourceMaps();
 


### PR DESCRIPTION
This swaps out the default style compilation to use Sass instead of PostCSS. SCSS is the default that Laravel comes with out-of-the-box, so it's what a lot of people are familiar with and can get rolling with, especially if they don't use TailwindCSS exclusively. You still get PostCSS processing the Tailwind directives, so you don't really lose anything from it.