### PR TITLE
Add default styling to handle invalid input red borders in Firefox

### DIFF
--- a/stubs/default/resources/sass/app.scss
+++ b/stubs/default/resources/sass/app.scss
@@ -8,6 +8,17 @@
 @tailwind base;
 
 /**
+ * Remove the default box-shadow for invalid elements to prevent
+ * inputs in Livewire components showing with a
+ * red border by default in Firefox.
+ *
+ * See: https://github.com/laravel-frontend-presets/tall/issues/7
+ */
+ input:invalid, textarea:invalid, select:invalid {
+    box-shadow: none;
+}
+
+/**
  * This injects any component classes registered by plugins.
  */
 @tailwind components;


### PR DESCRIPTION
Fixes #7 

For some reason, in Firefox only, when opening a page that has an input including `wire:model`, Firefox is treating the input as invalid by default, and putting a red border around it, even if the user has not interacted with it at this point.

This small addition of CSS covers this scenario so inputs don't look broken on page load.