### PR TITLE
Update the preset to replace the only other usage of RouteServiceProvider::HOME

### DIFF
--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -26,12 +26,16 @@ class TallPreset extends Preset
         static::updatePackages();
 
         $filesystem = new Filesystem();
-
         $filesystem->deleteDirectory(resource_path('sass'));
-
         $filesystem->copyDirectory(__DIR__ . '/../stubs/default', base_path());
 
-        static::updateDefaultHomeRoute();
+        static::updateFile(base_path('app/Providers/RouteServiceProvider.php'), function ($file) {
+            return str_replace("public const HOME = '/home';", "public const HOME = '/';", $file);
+        });
+
+        static::updateFile(base_path('app/Http/Middleware/RedirectIfAuthenticated.php'), function ($file) {
+            return str_replace("RouteServiceProvider::HOME", "route('home')", $file);
+        });
     }
 
     public static function installAuth()
@@ -49,10 +53,13 @@ class TallPreset extends Preset
         );
     }
 
-    protected static function updateDefaultHomeRoute()
+    /**
+     * Update the contents of a file with the logic of a given callback.
+     */
+    protected static function updateFile(string $path, callable $callback)
     {
-        $originalProvider = file_get_contents(app_path('Providers/RouteServiceProvider.php'));
-        $newProvider = str_replace("public const HOME = '/home';", "public const HOME = '/';", $originalProvider);
-        file_put_contents(app_path('Providers/RouteServiceProvider.php'), $newProvider);
+        $originalFileContents = file_get_contents($path);
+        $newFileContents = $callback($originalFileContents);
+        file_put_contents($path, $newFileContents);
     }
 }


### PR DESCRIPTION
This merge request updates the preset command to replace the usage of `RouteServiceProvider::HOME` within the `RedirectIfAuthenticated` middleware to use `route('home')` instead. This makes a default Laravel app completely used name routes instead of relying on a constant in only one place.