### PR TITLE
Add home link to logo

### DIFF
--- a/stubs/auth/resources/views/livewire/auth/login.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/login.blade.php
@@ -1,6 +1,8 @@
 <div>
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
-        <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        <a href="{{ route('home') }}">
+            <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        </a>
 
         <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 leading-9">
             Sign in to your account

--- a/stubs/auth/resources/views/livewire/auth/passwords/confirm.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/passwords/confirm.blade.php
@@ -1,6 +1,8 @@
 <div>
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
-        <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        <a href="{{ route('home') }}">
+            <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        </a>
 
         <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 leading-9">
             Confirm your password

--- a/stubs/auth/resources/views/livewire/auth/passwords/email.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/passwords/email.blade.php
@@ -1,6 +1,8 @@
 <div>
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
-        <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        <a href="{{ route('home') }}">
+            <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        </a>
 
         <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 leading-9">
             Reset password

--- a/stubs/auth/resources/views/livewire/auth/passwords/reset.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/passwords/reset.blade.php
@@ -1,6 +1,8 @@
 <div>
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
-        <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        <a href="{{ route('home') }}">
+            <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        </a>
 
         <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 leading-9">
             Reset password

--- a/stubs/auth/resources/views/livewire/auth/register.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/register.blade.php
@@ -1,6 +1,8 @@
 <div>
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
-        <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        <a href="{{ route('home') }}">
+            <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        </a>
 
         <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 leading-9">
             Create a new account

--- a/stubs/auth/resources/views/livewire/auth/verify.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/verify.blade.php
@@ -1,6 +1,8 @@
 <div>
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
-        <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        <a href="{{ route('home') }}">
+            <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+        </a>
 
         <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 leading-9">
             Verify your email address

--- a/stubs/default/resources/views/welcome.blade.php
+++ b/stubs/default/resources/views/welcome.blade.php
@@ -31,7 +31,9 @@
         <div class="flex items-center justify-center">
             <div class="flex flex-col justify-around">
                 <div class="space-y-6">
-                    <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+                    <a href="{{ route('home') }}">
+                        <x-logo class="w-auto h-16 mx-auto text-indigo-600" />
+                    </a>
 
                     <h1 class="text-5xl font-extrabold tracking-wider text-center text-gray-600">
                         {{ config('app.name') }}


### PR DESCRIPTION
I think we need to add link to `route('home')` to the logo. Specially when visiting the login & register page. Users can't go back to the home page.

I can also add it to the logo component but I don't think the link belongs there since the content is only SVG.

Let me know what you think.