### PR TITLE
Remove unnecessary ids from markup

### DIFF
--- a/stubs/auth/resources/views/livewire/auth/login.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/login.blade.php
@@ -28,7 +28,7 @@
                     </div>
 
                     @error('email')
-                        <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 
@@ -42,7 +42,7 @@
                     </div>
 
                     @error('password')
-                        <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 

--- a/stubs/auth/resources/views/livewire/auth/passwords/email.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/passwords/email.blade.php
@@ -39,7 +39,7 @@
                         </div>
 
                         @error('email')
-                            <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                         @enderror
                     </div>
 

--- a/stubs/auth/resources/views/livewire/auth/passwords/reset.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/passwords/reset.blade.php
@@ -24,7 +24,7 @@
                     </div>
 
                     @error('email')
-                        <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 
@@ -38,7 +38,7 @@
                     </div>
 
                     @error('password')
-                        <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 

--- a/stubs/auth/resources/views/livewire/auth/register.blade.php
+++ b/stubs/auth/resources/views/livewire/auth/register.blade.php
@@ -29,7 +29,7 @@
                     </div>
 
                     @error('name')
-                        <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 
@@ -43,7 +43,7 @@
                     </div>
 
                     @error('email')
-                        <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 
@@ -57,7 +57,7 @@
                     </div>
 
                     @error('password')
-                        <p class="mt-2 text-sm text-red-600" id="email-error">{{ $message }}</p>
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 


### PR DESCRIPTION
The ID attribute is unnecessary for the error text.
Keeping only required elements in HTML will make it easy to read, clean, low on size.