### PR TITLE
Update test for required field 'name'

### DIFF
--- a/stubs/auth/tests/Feature/Auth/RegisterTest.php
+++ b/stubs/auth/tests/Feature/Auth/RegisterTest.php
@@ -54,7 +54,7 @@ class RegisterTest extends TestCase
         Livewire::test('auth.register')
             ->set('name', '')
             ->call('register')
-            ->assertHasErrors(['email' => 'required']);
+            ->assertHasErrors(['name' => 'required']);
     }
 
     /** @test */


### PR DESCRIPTION
Currently test for a required name doesn't check the correct field, corrected to check for an error in the name property rather than email.