### PR TITLE
Trigger the Registered event

### DIFF
--- a/stubs/auth/app/Http/Livewire/Auth/Register.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Register.php
@@ -6,6 +6,7 @@ use App\Providers\RouteServiceProvider;
 use App\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Auth\Events\Registered;
 use Livewire\Component;
 
 class Register extends Component
@@ -36,7 +37,7 @@ class Register extends Component
             'password' => Hash::make($this->password),
         ]);
 
-        $user->sendEmailVerificationNotification();
+        event(new Registered($user));
 
         Auth::login($user, true);
 


### PR DESCRIPTION
Alternative to #26

Instead of firing `$user->sendEmailVerificationNotification();` directly, or checking if it has to be done manually; we can instead let this be handled by existing code from the framework itself. Triggering the `Registered` -event.

This way it also stays relevant to the documentation regarding Verification: https://laravel.com/docs/7.x/verification