### PR TITLE
Remove Tailwind custom forms

### DIFF
--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -9,7 +9,6 @@ use Laravel\Ui\Presets\Preset;
 class TallPreset extends Preset
 {
     const NPM_PACKAGES_TO_ADD = [
-        '@tailwindcss/custom-forms' => '^0.2',
         '@tailwindcss/ui' => '^0.1',
         'alpinejs' => '^2.0',
         'laravel-mix-tailwind' => '^0.1.0',

--- a/stubs/default/tailwind.config.js
+++ b/stubs/default/tailwind.config.js
@@ -27,7 +27,6 @@ module.exports = {
         },
     },
     plugins: [
-        require('@tailwindcss/custom-forms'),
         require('@tailwindcss/ui'),
     ],
 };


### PR DESCRIPTION
According with [Documentation of Tailwind UI](https://tailwindui.com/documentation#how-tailwindcss-ui-extends-tailwind) the `@tailwindcss/ui` includes the `@tailwindcss/custom-forms` plugin out of the box.

Is OK remove from our preset.