### PR TITLE
Install laravel-frontend-presets/tall as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This preset is intended to be installed into a fresh Laravel application. Follow
 
 Then simply run the following commands:
 ```bash
-composer require livewire/livewire laravel-frontend-presets/tall
+composer require livewire/livewire
+composer require laravel-frontend-presets/tall --dev
 php artisan ui tall
 npm install
 npm run dev
@@ -38,7 +39,8 @@ npm run dev
 If you would like to install the preset and its auth scaffolding in a fresh Laravel application, make sure to use the `--auth` flag on the `ui` command:
 
 ```bash
-composer require livewire/livewire laravel-frontend-presets/tall
+composer require livewire/livewire
+composer require laravel-frontend-presets/tall --dev
 php artisan ui tall --auth
 npm install
 npm run dev


### PR DESCRIPTION
Since the package can be removed after install, maybe we can also avoid having it landing into production environments.
Cheers