### PR TITLE
Fix for pagination "of" results disappearing bug when navigating from last page.

### DIFF
--- a/stubs/default/resources/views/vendor/livewire/pagination-links.blade.php
+++ b/stubs/default/resources/views/vendor/livewire/pagination-links.blade.php
@@ -29,8 +29,8 @@
                     <span class="font-medium">{{ $paginator->firstItem() }}</span>
                     to
                     <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                    of
-                    <span class="font-medium">{{ $paginator->total() }}</span>
+
+                    <span class="font-medium"> of {{ $paginator->total() }}</span>
                     results
                 </p>
             </div>

--- a/stubs/default/resources/views/vendor/livewire/pagination-links.blade.php
+++ b/stubs/default/resources/views/vendor/livewire/pagination-links.blade.php
@@ -25,13 +25,13 @@
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
                 <p class="text-sm text-gray-700 leading-5">
-                    Showing
+                    <span>Showing</span>
                     <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                    to
+                    <span>to</span>
                     <span class="font-medium">{{ $paginator->lastItem() }}</span>
-
-                    <span class="font-medium"> of {{ $paginator->total() }}</span>
-                    results
+                    <span>of</span>
+                    <span class="font-medium">{{ $paginator->total() }}</span>
+                    <span>results</span>
                 </p>
             </div>
 


### PR DESCRIPTION
There was a bug where the **"of"** word is not showing up after reaching last record of pagination then going back a page or to other numbered page.

![image](https://user-images.githubusercontent.com/19775853/86456272-62295580-bd54-11ea-8d91-3e98f0731829.png)

Steps to recreate:

- Go to last page of pagination
- Go back to other pages or click **<**