### PR TITLE
Redirect to the intended route upon login and registration

### DIFF
--- a/stubs/auth/app/Http/Livewire/Auth/Login.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Login.php
@@ -30,7 +30,7 @@ class Login extends Component
             return;
         }
 
-        redirect(route('home'));
+        redirect()->intended(route('home'));
     }
 
     public function render()

--- a/stubs/auth/app/Http/Livewire/Auth/Register.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Register.php
@@ -41,7 +41,7 @@ class Register extends Component
 
         Auth::login($user, true);
 
-        redirect(route('home'));
+        redirect()->intended(route('home'));
     }
 
     public function render()


### PR DESCRIPTION
If a user gets redirected to log in or register from a middleware, redirect them to their originally intended route once they've finished.