### PR TITLE
chore: update to Tailwind 1.5

### DIFF
--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -10,10 +10,10 @@ class TallPreset extends Preset
 {
     const NPM_PACKAGES_TO_ADD = [
         '@tailwindcss/ui' => '^0.3',
-        '@tailwindcss/typography' => '^1.4',
+        '@tailwindcss/typography' => '^0.2',
         'alpinejs' => '^2.0',
         'laravel-mix-tailwind' => '^0.1.0',
-        'tailwindcss' => '^1.4',
+        'tailwindcss' => '^1.5',
     ];
 
     const NPM_PACKAGES_TO_REMOVE = [

--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -9,7 +9,7 @@ use Laravel\Ui\Presets\Preset;
 class TallPreset extends Preset
 {
     const NPM_PACKAGES_TO_ADD = [
-        '@tailwindcss/ui' => '^0.3',
+        '@tailwindcss/ui' => '^0.4',
         '@tailwindcss/typography' => '^0.2',
         'alpinejs' => '^2.0',
         'laravel-mix-tailwind' => '^0.1.0',


### PR DESCRIPTION
This also resolves the version of the typography plugin which was incorrect (as it is still in 0.x, so should have been `0.1.4` rather than `1.4`).

Tailwind 1.5 doesn't support Typography 0.1.x, so this has also been updated to the latest version.

I've also bumped Tailwind UI to v0.4 which released yesterday.