### PR TITLE
Suggesting loading app.js after livewireScripts

### DIFF
--- a/stubs/default/resources/views/layouts/base.blade.php
+++ b/stubs/default/resources/views/layouts/base.blade.php
@@ -27,7 +27,7 @@
     <body>
         @yield('body')
 
-        <script src="{{ url(mix('js/app.js')) }}"></script>
         @livewireScripts
+        <script src="{{ url(mix('js/app.js')) }}"></script>
     </body>
 </html>


### PR DESCRIPTION
In a fresh installation of Laravel v7.21.1 and a simple Livewire form, I get the following error if alpine (app.js) is loaded before @livewireScripts.
Maybe it doesn't matter but I just wanted to suggest that the default boilerplate doesn't result in this error.

alpine.js?df24:1825 Uncaught TypeError: Cannot read property '$wire' of undefined
    at Livewire.value (index.js:29)
    at eval (eval at saferEval (alpine.js?df24:1804), <anonymous>:3:70)
    at saferEval (alpine.js?df24:115)
    at Component.evaluateReturnExpression (alpine.js?df24:1666)
    at new Component (alpine.js?df24:1431)
    at Object.initializeComponent (alpine.js?df24:1822)
    at eval (alpine.js?df24:1765)
    at eval (alpine.js?df24:1781)
    at NodeList.forEach (<anonymous>)
    at Object.discoverComponents (alpine.js?df24:1780)