### PR TITLE
Add $slot to app.blade.php

### DIFF
--- a/stubs/default/resources/views/layouts/app.blade.php
+++ b/stubs/default/resources/views/layouts/app.blade.php
@@ -2,4 +2,5 @@
 
 @section('body')
     @yield('content')
+    {{ $slot ?? null }}
 @endsection


### PR DESCRIPTION
As Livewire v2 will require a `{{ $slot }}` to make `Route::get()` work, thought it best to add it to the boilerplate.
With `??` to avoid undefined property error.