### PR TITLE
chore(add support for Livewire v2)

### DIFF
--- a/.github/workflows/phpunit.xml.stub
+++ b/.github/workflows/phpunit.xml.stub
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </coverage>
+    <php>
+        <server name="APP_ENV" value="testing"/>
+        <server name="BCRYPT_ROUNDS" value="4"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
+        <server name="MAIL_MAILER" value="array"/>
+        <server name="QUEUE_CONNECTION" value="sync"/>
+        <server name="SESSION_DRIVER" value="array"/>
+        <server name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+</phpunit>

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4]
-        laravel: [^7.0]
+        php: [7.3, 7.4]
+        laravel: [^8.0]
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
     steps:
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        extensions: dom, curl, libxml, mbstring, zip
+        extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
         coverage: none
     - name: Create Laravel app
       run: composer create-project laravel/laravel=${{ matrix.laravel }} ../app --prefer-dist
@@ -41,6 +41,12 @@ jobs:
       run: |
         cd ../app
         php artisan ui tall --auth
+    - name: Overwrite configuration
+      run: |
+        cd ../app
+        rm phpunit.xml
+        cp ../tall/.github/workflows/phpunit.xml.stub ./phpunit.xml
+
     - name: Execute tests
       run: |
         cd ../app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         cd ../app
         composer require livewire/livewire:^2.0
         composer config repositories.local '{"type": "path", "url": "../tall"}' --file composer.json
-        composer require laravel-frontend-presets/tall dev-master
+        composer require laravel-frontend-presets/tall
     - name: Install preset
       run: |
         cd ../app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         cd ../app
         composer require livewire/livewire:^2.0
         composer config repositories.local '{"type": "path", "url": "../tall"}' --file composer.json
-        composer require laravel-frontend-presets/tall
+        composer require laravel-frontend-presets/tall:@dev
     - name: Install preset
       run: |
         cd ../app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd ../app
-        composer require livewire/livewire
+        composer require livewire/livewire:^2.0
         composer config repositories.local '{"type": "path", "url": "../tall"}' --file composer.json
         composer require laravel-frontend-presets/tall dev-master
     - name: Install preset

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Some notable features of this package include:
 - Tailwind-powered pagination views
 - The [Tailwind UI](https://tailwindui.com) and Tailwind's [Custom Forms](https://github.com/tailwindcss/custom-forms) extensions available out-of-the-box
 
+> **Note**: If you're looking for an application boilerplate that supports the TALL stack, you should check out [Laravel Jetstream](https://github.com/laravel/jetstream). It comes with authentication scaffolding, account management, teams support.
+
 ## Installation
 
 This preset is intended to be installed into a fresh Laravel application. Follow [Laravel's installation instructions](https://laravel.com/docs/8.x/installation) to ensure you have a working environment before continuing.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some notable features of this package include:
 
 ## Installation
 
-This preset is intended to be installed into a fresh Laravel application. Follow [Laravel's installation instructions](https://laravel.com/docs/7.x/installation) to ensure you have a working environment before continuing.
+This preset is intended to be installed into a fresh Laravel application. Follow [Laravel's installation instructions](https://laravel.com/docs/8.x/installation) to ensure you have a working environment before continuing.
 
 ### Installation (without auth)
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         },
         {
             "name": "Ryan Chandler",
-            "email": "41837763+ryangjchandler@users.noreply.github.com"
+            "email": "support@ryangjchandler.co.uk"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "laravel/ui": "^2.0"
+        "laravel/ui": "^2.0",
+        "illuminate/support": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "illuminate/support": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -11,7 +11,7 @@ class TallPreset extends Preset
     const NPM_PACKAGES_TO_ADD = [
         '@tailwindcss/ui' => '^0.4',
         '@tailwindcss/typography' => '^0.2',
-        'alpinejs' => '^2.0',
+        'alpinejs' => '^2.6',
         'laravel-mix-tailwind' => '^0.1.0',
         'tailwindcss' => '^1.5',
     ];

--- a/stubs/auth/app/Http/Livewire/Auth/Login.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Login.php
@@ -35,6 +35,6 @@ class Login extends Component
 
     public function render()
     {
-        return view('livewire.auth.login');
+        return view('livewire.auth.login')->extends('layouts.auth');
     }
 }

--- a/stubs/auth/app/Http/Livewire/Auth/Login.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Login.php
@@ -30,7 +30,7 @@ class Login extends Component
             return;
         }
 
-        redirect()->intended(route('home'));
+        return redirect()->intended(route('home'));
     }
 
     public function render()

--- a/stubs/auth/app/Http/Livewire/Auth/Passwords/Confirm.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Passwords/Confirm.php
@@ -17,7 +17,7 @@ class Confirm extends Component
 
         session()->put('auth.password_confirmed_at', time());
 
-        redirect()->intended(route('home'));
+        return redirect()->intended(route('home'));
     }
 
     public function render()

--- a/stubs/auth/app/Http/Livewire/Auth/Passwords/Confirm.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Passwords/Confirm.php
@@ -22,6 +22,6 @@ class Confirm extends Component
 
     public function render()
     {
-        return view('livewire.auth.passwords.confirm');
+        return view('livewire.auth.passwords.confirm')->extends('layouts.auth');
     }
 }

--- a/stubs/auth/app/Http/Livewire/Auth/Passwords/Email.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Passwords/Email.php
@@ -42,6 +42,6 @@ class Email extends Component
 
     public function render()
     {
-        return view('livewire.auth.passwords.email');
+        return view('livewire.auth.passwords.email')->extends('layouts.auth');
     }
 }

--- a/stubs/auth/app/Http/Livewire/Auth/Passwords/Reset.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Passwords/Reset.php
@@ -87,6 +87,6 @@ class Reset extends Component
 
     public function render()
     {
-        return view('livewire.auth.passwords.reset');
+        return view('livewire.auth.passwords.reset')->extends('layouts.auth');
     }
 }

--- a/stubs/auth/app/Http/Livewire/Auth/Register.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Register.php
@@ -46,6 +46,6 @@ class Register extends Component
 
     public function render()
     {
-        return view('livewire.auth.register');
+        return view('livewire.auth.register')->extends('layouts.auth');
     }
 }

--- a/stubs/auth/app/Http/Livewire/Auth/Register.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Register.php
@@ -41,7 +41,7 @@ class Register extends Component
 
         Auth::login($user, true);
 
-        redirect()->intended(route('home'));
+        return redirect()->intended(route('home'));
     }
 
     public function render()

--- a/stubs/auth/app/Http/Livewire/Auth/Register.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Register.php
@@ -3,7 +3,7 @@
 namespace App\Http\Livewire\Auth;
 
 use App\Providers\RouteServiceProvider;
-use App\User;
+use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Auth\Events\Registered;

--- a/stubs/auth/app/Http/Livewire/Auth/Verify.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Verify.php
@@ -23,6 +23,6 @@ class Verify extends Component
 
     public function render()
     {
-        return view('livewire.auth.verify');
+        return view('livewire.auth.verify')->extends('layouts.auth');
     }
 }

--- a/stubs/auth/resources/views/layouts/auth.blade.php
+++ b/stubs/auth/resources/views/layouts/auth.blade.php
@@ -3,5 +3,9 @@
 @section('body')
     <div class="flex flex-col justify-center min-h-screen py-12 bg-gray-50 sm:px-6 lg:px-8">
         @yield('content')
+
+        @isset($slot)
+            {{ $slot }}
+        @endisset
     </div>
 @endsection

--- a/stubs/auth/routes/web.php
+++ b/stubs/auth/routes/web.php
@@ -1,5 +1,11 @@
 <?php
 
+use App\Http\Livewire\Auth\Login;
+use App\Http\Livewire\Auth\Passwords\Confirm;
+use App\Http\Livewire\Auth\Passwords\Email;
+use App\Http\Livewire\Auth\Passwords\Reset;
+use App\Http\Livewire\Auth\Register;
+use App\Http\Livewire\Auth\Verify;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -15,29 +21,27 @@ use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'welcome')->name('home');
 
-Route::layout('layouts.auth')->group(function () {
-    Route::middleware('guest')->group(function () {
-        Route::livewire('login', 'auth.login')
-            ->name('login');
+Route::middleware('guest')->group(function () {
+    Route::get('login', Login::class)
+        ->name('login');
 
-        Route::livewire('register', 'auth.register')
-            ->name('register');
-    });
+    Route::get('register', Register::class)
+        ->name('register');
+});
 
-    Route::livewire('password/reset', 'auth.passwords.email')
-        ->name('password.request');
+Route::get('password/reset', Email::class)
+    ->name('password.request');
 
-    Route::livewire('password/reset/{token}', 'auth.passwords.reset')
-        ->name('password.reset');
+Route::get('password/reset/{token}', Reset::class)
+    ->name('password.reset');
 
-    Route::middleware('auth')->group(function () {
-        Route::livewire('email/verify', 'auth.verify')
-            ->middleware('throttle:6,1')
-            ->name('verification.notice');
+Route::middleware('auth')->group(function () {
+    Route::get('email/verify', Verify::class)
+        ->middleware('throttle:6,1')
+        ->name('verification.notice');
 
-        Route::livewire('password/confirm', 'auth.passwords.confirm')
-            ->name('password.confirm');
-    });
+    Route::get('password/confirm', Confirm::class)
+        ->name('password.confirm');
 });
 
 Route::middleware('auth')->group(function () {

--- a/stubs/auth/routes/web.php
+++ b/stubs/auth/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\Auth\EmailVerificationController;
+use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Livewire\Auth\Login;
 use App\Http\Livewire\Auth\Passwords\Confirm;
 use App\Http\Livewire\Auth\Passwords\Email;
@@ -45,10 +47,10 @@ Route::middleware('auth')->group(function () {
 });
 
 Route::middleware('auth')->group(function () {
-    Route::get('email/verify/{id}/{hash}', 'Auth\EmailVerificationController')
+    Route::get('email/verify/{id}/{hash}', EmailVerificationController::class)
         ->middleware('signed')
         ->name('verification.verify');
 
-    Route::post('logout', 'Auth\LogoutController')
+    Route::post('logout', LogoutController::class)
         ->name('logout');
 });

--- a/stubs/auth/tests/Feature/Auth/LoginTest.php
+++ b/stubs/auth/tests/Feature/Auth/LoginTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\User;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
@@ -24,7 +24,7 @@ class LoginTest extends TestCase
     /** @test */
     public function is_redirected_if_already_logged_in()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
 
         $this->be($user);
 
@@ -35,7 +35,7 @@ class LoginTest extends TestCase
     /** @test */
     public function a_user_can_login()
     {
-        $user = factory(User::class)->create(['password' => Hash::make('password')]);
+        $user = User::factory()->create(['password' => Hash::make('password')]);
 
         Livewire::test('auth.login')
             ->set('email', $user->email)
@@ -48,7 +48,7 @@ class LoginTest extends TestCase
     /** @test */
     public function is_redirected_to_the_home_page_after_login()
     {
-        $user = factory(User::class)->create(['password' => Hash::make('password')]);
+        $user = User::factory()->create(['password' => Hash::make('password')]);
 
         Livewire::test('auth.login')
             ->set('email', $user->email)
@@ -60,7 +60,7 @@ class LoginTest extends TestCase
     /** @test */
     public function email_is_required()
     {
-        $user = factory(User::class)->create(['password' => Hash::make('password')]);
+        $user = User::factory()->create(['password' => Hash::make('password')]);
 
         Livewire::test('auth.login')
             ->set('password', 'password')
@@ -71,7 +71,7 @@ class LoginTest extends TestCase
     /** @test */
     public function email_must_be_valid_email()
     {
-        $user = factory(User::class)->create(['password' => Hash::make('password')]);
+        $user = User::factory()->create(['password' => Hash::make('password')]);
 
         Livewire::test('auth.login')
             ->set('email', 'invalid-email')
@@ -83,7 +83,7 @@ class LoginTest extends TestCase
     /** @test */
     public function password_is_required()
     {
-        $user = factory(User::class)->create(['password' => Hash::make('password')]);
+        $user = User::factory()->create(['password' => Hash::make('password')]);
 
         Livewire::test('auth.login')
             ->set('email', $user->email)
@@ -94,7 +94,7 @@ class LoginTest extends TestCase
     /** @test */
     public function bad_login_attempt_shows_message()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
 
         Livewire::test('auth.login')
             ->set('email', $user->email)

--- a/stubs/auth/tests/Feature/Auth/LogoutTest.php
+++ b/stubs/auth/tests/Feature/Auth/LogoutTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\User;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Tests\TestCase;
@@ -14,7 +14,7 @@ class LogoutTest extends TestCase
     /** @test */
     public function an_authenticated_user_can_log_out()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $this->be($user);
 
         $this->post(route('logout'))

--- a/stubs/auth/tests/Feature/Auth/Passwords/ConfirmTest.php
+++ b/stubs/auth/tests/Feature/Auth/Passwords/ConfirmTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth\Passwords;
 
-use App\User;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
@@ -25,7 +25,7 @@ class ConfirmTest extends TestCase
     /** @test */
     public function a_user_must_confirm_their_password_before_visiting_a_protected_page()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
         $this->be($user);
 
         $this->get('/must-be-confirmed')
@@ -47,7 +47,7 @@ class ConfirmTest extends TestCase
     /** @test */
     public function a_user_must_enter_their_own_password_to_confirm_it()
     {
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
             'password' => Hash::make('password'),
         ]);
 
@@ -60,7 +60,7 @@ class ConfirmTest extends TestCase
     /** @test */
     public function a_user_who_confirms_their_password_will_get_redirected()
     {
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
             'password' => Hash::make('password'),
         ]);
 

--- a/stubs/auth/tests/Feature/Auth/Passwords/EmailTest.php
+++ b/stubs/auth/tests/Feature/Auth/Passwords/EmailTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth\Passwords;
 
-use App\User;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -39,7 +39,7 @@ class EmailTest extends TestCase
     /** @test */
     public function a_user_who_enters_a_valid_email_address_will_get_sent_an_email()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
 
         Livewire::test('auth.passwords.email')
             ->set('email', $user->email)

--- a/stubs/auth/tests/Feature/Auth/Passwords/ResetTest.php
+++ b/stubs/auth/tests/Feature/Auth/Passwords/ResetTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth\Passwords;
 
-use App\User;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
@@ -19,7 +19,7 @@ class ResetTest extends TestCase
     /** @test */
     public function can_view_password_reset_page()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
 
         $token = Str::random(16);
 
@@ -40,7 +40,7 @@ class ResetTest extends TestCase
     /** @test */
     public function can_reset_password()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
 
         $token = Str::random(16);
 

--- a/stubs/auth/tests/Feature/Auth/RegisterTest.php
+++ b/stubs/auth/tests/Feature/Auth/RegisterTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\User;
+use App\Models\User;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Illuminate\Support\Facades\Hash;
@@ -27,7 +27,7 @@ class RegisterTest extends TestCase
     /** @test */
     public function is_redirected_if_already_logged_in()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
 
         $this->be($user);
 
@@ -84,7 +84,7 @@ class RegisterTest extends TestCase
     /** @test */
     function email_hasnt_been_taken_already()
     {
-        factory(User::class)->create(['email' => 'tallstack@example.com']);
+        User::factory()->create(['email' => 'tallstack@example.com']);
 
         Livewire::test('auth.register')
             ->set('email', 'tallstack@example.com')
@@ -95,7 +95,7 @@ class RegisterTest extends TestCase
     /** @test */
     function see_email_hasnt_already_been_taken_validation_message_as_user_types()
     {
-        factory(User::class)->create(['email' => 'tallstack@example.com']);
+        User::factory()->create(['email' => 'tallstack@example.com']);
 
         Livewire::test('auth.register')
             ->set('email', 'smallstack@gmail.com')

--- a/stubs/auth/tests/Feature/Auth/VerifyTest.php
+++ b/stubs/auth/tests/Feature/Auth/VerifyTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\User;
+use App\Models\User;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Illuminate\Support\Facades\Hash;
@@ -20,7 +20,7 @@ class VerifyTest extends TestCase
     /** @test */
     public function can_view_verification_page()
     {
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
             'email_verified_at' => null,
         ]);
 
@@ -34,7 +34,7 @@ class VerifyTest extends TestCase
     /** @test */
     public function can_resend_verification_email()
     {
-        $user = factory(User::class)->create();
+        $user = User::factory()->create();
 
         Livewire::actingAs($user);
 
@@ -46,7 +46,7 @@ class VerifyTest extends TestCase
     /** @test */
     public function can_verify()
     {
-        $user = factory(User::class)->create([
+        $user = User::factory()->create([
             'email_verified_at' => null,
         ]);
 

--- a/stubs/default/resources/views/layouts/base.blade.php
+++ b/stubs/default/resources/views/layouts/base.blade.php
@@ -9,7 +9,7 @@
         @else
             <title>{{ config('app.name') }}</title>
         @endif
-		
+
         <!-- Favicon -->
 		<link rel="shortcut icon" href="{{ url(asset('favicon.ico')) }}">
 
@@ -20,6 +20,9 @@
         <link rel="stylesheet" href="{{ url(mix('css/app.css')) }}">
         @livewireStyles
 
+        <!-- Scripts -->
+        <script src="{{ url(mix('js/app.js')) }}" defer></script>
+
         <!-- CSRF Token -->
         <meta name="csrf-token" content="{{ csrf_token() }}">
     </head>
@@ -27,7 +30,6 @@
     <body>
         @yield('body')
 
-        <script src="{{ url(mix('js/app.js')) }}"></script>
         @livewireScripts
     </body>
 </html>


### PR DESCRIPTION
This PR closes #63 and closes #60 by adding support for Livewire v2. Here is a list of changes made:

* Remove `Route::livewire()` methods in favour of `Route::get()` methods.
* Remove usage of `Route::layout()` methods in favour of `view()->extends()` inside of each Livewire component.
* Add an `isset` check for the `$slot` variable inside of `layouts.auth` so that regular `@section('content')` can be used, but it will also support Livewire's default usage of `{{ $slot }}`.
* Add a note to the README about Jetstream and point to it if you're looking for more than just authentication scaffolding. 
* Update the version of Alpine that is added to the `package.json` file from `^2.0` to `^2.6` since this version has all of the latest changes required for Livewire v2 to work correctly.
* Move the `app.js` bundle loading into the `<head>` of the document with the `defer` attribute (related to #58).
* Update the test suite to work with Laravel 8 but also fixes the local repository not loading correctly on pull requests. 
* Add missing return statements to the Livewire redirects (related to #56).