### PR TITLE
Laravel 8 requires `laravel/ui:^3.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "laravel/ui": "^2.0|^3.0",
+        "laravel/ui": "^3.0",
         "illuminate/support": "^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "laravel/ui": "^3.0",
+        "laravel/ui": "^2.0|^3.0",
         "illuminate/support": "^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "laravel/ui": "^2.0",
+        "laravel/ui": "^3.0",
         "illuminate/support": "^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 8 require Laravel UI 3.0 or greater: https://laravel.com/docs/8.x/upgrade
Without this installation fails:
```
  Problem 1
    - Can only install one of: laravel/ui[3.x-dev, 2.x-dev].
    - Can only install one of: laravel/ui[v3.0.0, 2.x-dev].
    - laravel-frontend-presets/tall v2.0.0 requires laravel/ui ^2.0 -> satisfiable by laravel/ui[2.x-dev].
    - Installation request for laravel-frontend-presets/tall ^2.0 -> satisfiable by laravel-frontend-presets/tall[v2.0.0].
    - Installation request for laravel/ui ^3.0 -> satisfiable by laravel/ui[3.x-dev, v3.0.0].
```