### PR TITLE
Prefill email address in password reset form

### DIFF
--- a/stubs/auth/app/Http/Livewire/Auth/Passwords/Reset.php
+++ b/stubs/auth/app/Http/Livewire/Auth/Passwords/Reset.php
@@ -26,6 +26,7 @@ class Reset extends Component
 
     public function mount($token)
     {
+        $this->email = request()->query('email', '');
         $this->token = $token;
     }
 

--- a/stubs/auth/tests/Feature/Auth/Passwords/ResetTest.php
+++ b/stubs/auth/tests/Feature/Auth/Passwords/ResetTest.php
@@ -34,6 +34,7 @@ class ResetTest extends TestCase
             'token' => $token,
         ]))
             ->assertSuccessful()
+            ->assertSee($user->email)
             ->assertSeeLivewire('auth.passwords.reset');
     }
 


### PR DESCRIPTION
In the password reset form it would be nice to prefill the email field with the query parameter.