### PR TITLE
moving Alpine JS from Bootstrap.js to app.js

### DIFF
--- a/stubs/default/resources/js/app.js
+++ b/stubs/default/resources/js/app.js
@@ -1,1 +1,4 @@
 require('./bootstrap');
+import Alpine from 'alpinejs';
+window.Alpine = Alpine;
+Alpine.start();

--- a/stubs/default/resources/js/bootstrap.js
+++ b/stubs/default/resources/js/bootstrap.js
@@ -1,6 +1,3 @@
-import Alpine from 'alpinejs';
-window.Alpine = Alpine;
-Alpine.start();
 
 /**
  * Echo exposes an expressive API for subscribing to channels and listening


### PR DESCRIPTION
Hey everyone,
Due to the issue I had regarding adding Alpine js plugins to the project such as Alpine-clipboard which have to be added before the Alpine js itself, struggled for hours and even people from the community were not able to answer the question, found out the Alpine js is declared in the ```bootstrap.js``` instead of ```app.js``` which is the proper place to declare a js package and/or alpine plugins. Therefore with the suggestion of @danharrin I'm opening this pull request to make sure other developers don't face the problem I did since ```bootstrap.js``` is not the right place to declare Alpine js and I don't think people will look into that file looking for Alpine js.