### PR TITLE
Needs to be in array

### DIFF
--- a/stubs/default/resources/views/layouts/base.blade.php
+++ b/stubs/default/resources/views/layouts/base.blade.php
@@ -16,7 +16,7 @@
         <!-- Fonts -->
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
 
-        @vite('resources/sass/app.scss', 'resources/js/app.js')
+        @vite(['resources/sass/app.scss', 'resources/js/app.js'])
         @livewireStyles
         @livewireScripts
 


### PR DESCRIPTION
New install of L9 and the TALL framework and AlpineJS wouldn't work. Needed to wrap this in an array for it to load the app.js. 