### PR TITLE
Resolved "Uncaught ReferenceError: require is not defined"

### DIFF
--- a/stubs/default/resources/js/app.js
+++ b/stubs/default/resources/js/app.js
@@ -1,4 +1,4 @@
-require('./bootstrap')
+import './bootstrap';
 import Alpine from 'alpinejs'
 window.Alpine = Alpine
 Alpine.start()


### PR DESCRIPTION
Changed require() to import as used originally in the fresh install of Laravel.