### PR TITLE
Removed AlpineJS initialization and its npm dependency

### DIFF
--- a/src/TallPreset.php
+++ b/src/TallPreset.php
@@ -11,7 +11,6 @@ class TallPreset extends Preset
     const NPM_PACKAGES_TO_ADD = [
         '@tailwindcss/forms' => '^0.5',
         '@tailwindcss/typography' => '^0.5',
-        'alpinejs' => '^3.8',
         'autoprefixer' => '^10.4',
         'resolve-url-loader' => '^3.1',
         'sass' => '^1.3',

--- a/stubs/default/resources/js/app.js
+++ b/stubs/default/resources/js/app.js
@@ -1,4 +1,1 @@
 import './bootstrap';
-import Alpine from 'alpinejs'
-window.Alpine = Alpine
-Alpine.start()


### PR DESCRIPTION
AlpineJS is already included in Livewire v3, so, no explicit installation and initialization is required anymore.