### PR TITLE
New install not working (postcss incorrectly configured) #138

### DIFF
--- a/stubs/default/postcss.config.js
+++ b/stubs/default/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
     plugins: {
         tailwindcss: {},
         autoprefixer: {},


### PR DESCRIPTION
Hi, @danharrin

I faced installation error while,` npm run dev`
I had read all of previous discussions.

Here i tried, fresh :
![image](https://github.com/user-attachments/assets/3527387d-310c-423b-baf4-64e34cbe3bbd)


Here i tried, postcss.config.js renaming to postcss.config.cjs :
though not working...
![image](https://github.com/user-attachments/assets/c00dd0c5-3987-449e-93fa-a24880d82b79)

But here, postcss.config.js with
module.exports = {
    plugins: {
        tailwindcss: {},
        autoprefixer: {},
    },
}

![image](https://github.com/user-attachments/assets/39d9537e-358b-465c-9496-42bcd60151e5)

It's fixed.